### PR TITLE
Fix screen recording protection: Trigger observer immediately

### DIFF
--- a/Source/ScreenShield.swift
+++ b/Source/ScreenShield.swift
@@ -25,7 +25,7 @@ public class ScreenShield {
     }
     
     public func protectFromScreenRecording(_ blockingScreenMessage: String? = nil) {
-        recordingObservation =  UIScreen.main.observe(\UIScreen.isCaptured, options: [.new]) { [weak self] screen, change in
+        recordingObservation =  UIScreen.main.observe(\UIScreen.isCaptured, options: [.new, .initial]) { [weak self] screen, change in
             
             if let errMessage = blockingScreenMessage {
                 self?.blockingScreenMessage = errMessage


### PR DESCRIPTION
- Added .initial option to UIScreen.isCaptured observer to ensure the closure runs immediately with the current value.
- Fixes issue where protection would only activate if the method was called before screen recording started.